### PR TITLE
notification bug fix

### DIFF
--- a/MystatDesktopWpf/UserControls/NotificationSettings.xaml
+++ b/MystatDesktopWpf/UserControls/NotificationSettings.xaml
@@ -54,7 +54,7 @@
                                          Content="{DynamicResource m_SettingsOfNotification1Radio1}" Margin="0, 0, 0, 8" Grid.Row="1" GroupName="DelayMode"/>
                         <TextBox MaxLength="2" Margin="8, 0, 8, 0" Width="20" HorizontalContentAlignment="Center"
                                      materialDesign:TextFieldAssist.CharacterCounterVisibility="Collapsed" x:Name="minutesTextBox"
-                                     Text="{Binding NotificationDelay, Mode=OneTime}" PreviewTextInput="TextBox_PreviewTextInput" TextChanged="minutesTextBox_TextChanged" />
+                                     Text="{Binding NotificationDelay, Mode=OneTime}" PreviewTextInput="TextBox_PreviewTextInput"/>
                         <Label x:Name="minutesLabel" Content="{DynamicResource m_SettingsOfNotification1Radio1p2}"/>
                     </StackPanel>
                     <RadioButton IsChecked="{Binding Path=DelayMode, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static domain:NotificationDelayMode.Both}}"

--- a/MystatDesktopWpf/UserControls/NotificationSettings.xaml.cs
+++ b/MystatDesktopWpf/UserControls/NotificationSettings.xaml.cs
@@ -33,6 +33,8 @@ namespace MystatDesktopWpf.UserControls
             DataContext = viewModel;
 
             InitializeComponent();
+            // Вешаем только сейчас, чтобы не активировать ViewModel
+            minutesTextBox.TextChanged += minutesTextBox_TextChanged;
 
             viewModel.PropertyChanged += ViewModel_PropertyChanged;
             ViewModel_PropertyChanged(null, new PropertyChangedEventArgs("NotificationVolume"));


### PR DESCRIPTION
Когда юзер заходил в настройки, уведомления включались вне зависимости от того, включены они у него или нет. Это происходило из-за лишней активации ViewModel, которая и включала уведомления. Теперь такого нет.