### PR TITLE
Updater and xaml fixes

### DIFF
--- a/MystatDesktopWpf/Updater/UpdateWindow.xaml.cs
+++ b/MystatDesktopWpf/Updater/UpdateWindow.xaml.cs
@@ -29,6 +29,7 @@ namespace MystatDesktopWpf.Updater
                 {
                     statusTextBox.Text = (string)App.Current.FindResource("m_DownloadingUpdate");
                     await UpdateHandler.RequestUpdate();
+                    return;
                 }
             }
             catch (Exception) { } // TODO Log

--- a/MystatDesktopWpf/UserControls/Menus/MainMenu.xaml
+++ b/MystatDesktopWpf/UserControls/Menus/MainMenu.xaml
@@ -33,9 +33,9 @@
             <StackPanel x:Name="headerBar" Orientation="Horizontal" HorizontalAlignment="Left"
                         Grid.Column="1" VerticalAlignment="Center" Margin="16,0,0,0"
                         d:DataContext="{d:DesignInstance Type=viewmodels:HeaderBarViewModel}">
-                <TextBlock Text="{Binding Name}" Margin="0,0,8,0"/>
+                <TextBlock Text="{Binding Name}" Margin="0,0,16,0"/>
                 <materialDesign:PackIcon Kind="Account"/>
-                <TextBlock Text="{Binding Group}" Margin="4,0,8,0"/>
+                <TextBlock Text="{Binding Group}" Margin="4,0,16,0"/>
                 <materialDesign:PackIcon Kind="Star" Foreground="#a67afa"/>
                 <TextBlock Text="{Binding Points}" Margin="4,0,8,0"/>
                 <materialDesign:PackIcon Kind="Diamond" Foreground="#73a0ec"/>

--- a/MystatDesktopWpf/UserControls/NotificationSettings.xaml
+++ b/MystatDesktopWpf/UserControls/NotificationSettings.xaml
@@ -49,13 +49,13 @@
                     <RadioButton IsChecked="{Binding Path=DelayMode, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static domain:NotificationDelayMode.WithoutDelay}}"
                                      Content="{DynamicResource m_SettingsOfNotification1Radio0}" Margin="0,0,0,8" GroupName="DelayMode"/>
 
-                    <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.RowSpan="2" VerticalAlignment="Center">
+                    <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.RowSpan="2" Margin="0,-4,0,4">
                         <RadioButton IsChecked="{Binding Path=DelayMode, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static domain:NotificationDelayMode.Delayed}}"
-                                         Content="{DynamicResource m_SettingsOfNotification1Radio1}" Margin="0, 0, 0, 8" Grid.Row="1" GroupName="DelayMode"/>
-                        <TextBox MaxLength="2" Margin="8, 0, 8, 0" Width="20" HorizontalContentAlignment="Center"
+                                     Content="{DynamicResource m_SettingsOfNotification1Radio1}" Margin="0, 0, 0, 0" Grid.Row="1" GroupName="DelayMode"/>
+                        <TextBox MaxLength="2" Margin="4, 0, 0, 0" Width="20" HorizontalContentAlignment="Center" VerticalContentAlignment="Bottom"
                                      materialDesign:TextFieldAssist.CharacterCounterVisibility="Collapsed" x:Name="minutesTextBox"
                                      Text="{Binding NotificationDelay, Mode=OneTime}" PreviewTextInput="TextBox_PreviewTextInput"/>
-                        <Label x:Name="minutesLabel" Content="{DynamicResource m_SettingsOfNotification1Radio1p2}"/>
+                        <Label x:Name="minutesLabel" Content="{DynamicResource m_SettingsOfNotification1Radio1p2}" Margin="0,0,0,0"/>
                     </StackPanel>
                     <RadioButton IsChecked="{Binding Path=DelayMode, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static domain:NotificationDelayMode.Both}}"
                              Content="{DynamicResource m_SettingsOfNotification1Radio2}" Margin="0,0,0,8" Grid.Row="2" GroupName="DelayMode"/>

--- a/MystatDesktopWpf/UserControls/ThemeSettings.xaml
+++ b/MystatDesktopWpf/UserControls/ThemeSettings.xaml
@@ -32,7 +32,7 @@
                 </Grid.RowDefinitions>
                 <TextBox Margin="2,0,10,2"
                        materialDesign:HintAssist.Hint="{DynamicResource m_HEXColor}"
-                       DockPanel.Dock="Top"
+                       DockPanel.Dock="Top" MaxLength="9" materialDesign:TextFieldAssist.CharacterCounterVisibility="Collapsed"
                        Style="{StaticResource MaterialDesignFilledTextBox}"
                        Text="{Binding Color, ElementName=ColorPicker, UpdateSourceTrigger=PropertyChanged}" />
                 <Rectangle Grid.Row="1" Margin="2,0,10,2" Fill="{Binding Color, ElementName=ColorPicker, Converter={StaticResource ColorToBrushConverter}}" />


### PR DESCRIPTION
- пароль при автоматическом логине после обновления теперь корректно вводится
- установлено ограничение на поле Hex color в Theme settings так на 9 символов - как раз на hex code.
- Выровнено поле ввода задержки оповещения о начале пары
- Сгруппированы отступами блоки информации в верхней панели